### PR TITLE
Header name change for DROT2 and DROT3

### DIFF
--- a/irdap/irdap.py
+++ b/irdap/irdap.py
@@ -4204,11 +4204,20 @@ def correct_instrumental_polarization_effects(cube_I_Q_double_sum,
     for i, header_sel in enumerate(header):
         p[i] = compute_mean_angle([header_sel['ESO TEL PARANG START'], header_sel['ESO TEL PARANG END']])
         a_start[i] = header_sel['ESO TEL ALT']
-        theta_hwp[i] = np.mod(compute_mean_angle([np.mod(header_sel['ESO INS4 DROT3 BEGIN'] - 152.15, 360), np.mod(header_sel['ESO INS4 DROT3 END'] - 152.15, 360)]), 180)
+        try:
+            theta_hwp[i] = np.mod(compute_mean_angle([np.mod(header_sel['ESO INS4 DROT3 BEGIN'] - 152.15, 360), np.mod(header_sel['ESO INS4 DROT3 END'] - 152.15, 360)]), 180)
+        except:
+            theta_hwp[i] = np.mod(compute_mean_angle([np.mod(header_sel['ESO INS4 DROT3 START'] - 152.15, 360), np.mod(header_sel['ESO INS4 DROT3 END'] - 152.15, 360)]), 180)
         if tracking_mode_used == 'FIELD':
-            theta_der[i] = np.mod(compute_mean_angle([header_sel['ESO INS4 DROT2 BEGIN'], header_sel['ESO INS4 DROT2 END']]), 360)
+            try:
+                theta_der[i] = np.mod(compute_mean_angle([header_sel['ESO INS4 DROT2 BEGIN'], header_sel['ESO INS4 DROT2 END']]), 360)
+            except:
+                theta_der[i] = np.mod(compute_mean_angle([header_sel['ESO INS4 DROT2 START'], header_sel['ESO INS4 DROT2 END']]), 360)
         elif tracking_mode_used == 'PUPIL':
-            theta_der[i] = np.mod(compute_mean_angle([header_sel['ESO INS4 DROT2 BEGIN'], header_sel['ESO INS4 DROT2 END']]) + 0.5*pupil_offset, 360)
+            try:
+                theta_der[i] = np.mod(compute_mean_angle([header_sel['ESO INS4 DROT2 BEGIN'], header_sel['ESO INS4 DROT2 END']]) + 0.5*pupil_offset, 360)
+            except:
+                theta_der[i] = np.mod(compute_mean_angle([header_sel['ESO INS4 DROT2 START'], header_sel['ESO INS4 DROT2 END']]) + 0.5*pupil_offset, 360)
         mjd[i] = header_sel['MJD-OBS']
         exposure_time[i] = header_sel['ESO DET SEQ1 DIT']
         NDIT[i] = header_sel['ESO DET NDIT']


### PR DESCRIPTION
I spotted the header name change in a 2021 data. Temporary solution for now (the csv file kept the same, need to change it as well). The change I made was able to reduce the 2021 data, but if the meaning of the headers do have changed, please reject this pull request.