### PR TITLE
Default center for Ks data with no 'INS.COMB.ICOR'

### DIFF
--- a/irdap/irdap.py
+++ b/irdap/irdap.py
@@ -3340,9 +3340,12 @@ def preprocess_data(frames_to_remove=[],
             # Determine coronagraph used and set center coordinates
             coronagraph_used = pyfits.getheader(path_object_files[0])['ESO INS COMB ICOR']
 
-            if coronagraph_used == 'N_ALC_Ks':
+            if coronagraph_used == '': #if 'ESO INS COMB ICOR' was not written, find the 'ESO INS1 FILT ID' keyword instead
+                coronagraph_used = pyfits.getheader(path_object_files[0])['ESO INS1 FILT ID']
+
+            if coronagraph_used == 'N_ALC_Ks' or coronagraph_used == 'FILT_BBF_Ks':
                 object_center_coordinates = (477, 534, 1503, 523)
-                printandlog('\nobject_center_coordinates is \'automatic\': changing it to ' + str(tuple(x + 1 for x in object_center_coordinates)) + ' because the coronagraph used is N_ALC_Ks.')
+                printandlog('\nobject_center_coordinates is \'automatic\': changing it to ' + str(tuple(x + 1 for x in object_center_coordinates)) + ' because the coronagraph used is ' + coronagraph_used + '.')
             else:
                 object_center_coordinates = (477, 521, 1503, 511)
                 printandlog('\nobject_center_coordinates is \'automatic\': changing it to ' + str(tuple(x + 1 for x in object_center_coordinates)) + ' because the coronagraph used is not N_ALC_Ks.')
@@ -3383,9 +3386,12 @@ def preprocess_data(frames_to_remove=[],
         # Determine coronagraph used and set center coordinates
         coronagraph_used = pyfits.getheader(path_object_files[0])['ESO INS COMB ICOR']
 
-        if coronagraph_used == 'N_ALC_Ks':
+        if coronagraph_used == '': #if 'ESO INS COMB ICOR' was not written, find the 'ESO INS1 FILT ID' keyword instead
+            coronagraph_used = pyfits.getheader(path_object_files[0])['ESO INS1 FILT ID']
+
+        if coronagraph_used == 'N_ALC_Ks' or coronagraph_used == 'FILT_BBF_Ks':
             object_center_coordinates = (477, 534, 1503, 523)
-            printandlog('\nobject_center_coordinates is \'automatic\': changing it to ' + str(tuple(x + 1 for x in object_center_coordinates)) + ' because the coronagraph used is N_ALC_Ks.')
+            printandlog('\nobject_center_coordinates is \'automatic\': changing it to ' + str(tuple(x + 1 for x in object_center_coordinates)) + ' because the coronagraph used is ' + coronagraph_used + '.')
         else:
             object_center_coordinates = (477, 521, 1503, 511)
             printandlog('\nobject_center_coordinates is \'automatic\': changing it to ' + str(tuple(x + 1 for x in object_center_coordinates)) + ' because the coronagraph used is not N_ALC_Ks.')


### PR DESCRIPTION
Problem: For some Ks-band observations, they were not given an 'ESO INS COMB ICOR' header. As a result, the `coronagraph_used ` parameter gets nothing, and the default centers were (477, 521, 1503, 511).

Fix: This code reads 'ESO INS1 FILT ID' and checks whether the observations were taken in 'FILT_BBF_Ks' . If yes, then we can correctly get the (477, 534, 1503, 523) combination for Ks observations.

Future fix: I think checking `coronagraph_used[-2: ] == 'Ks'` for the name after reading 'ESO INS1 FILT ID' would be a neat fix, but that might be less informative than the code that I have above.

I have tested this fix on the observations from 2020 12 26 and 2021 12 28. Both works perfectly. If there are no public data taken in this mode, you can contact me and I will ask the PI for permission.